### PR TITLE
gif_to_raw.py: Tostring fix for Python 3.9

### DIFF
--- a/examples/change_boot_anim/gif_to_raw.py
+++ b/examples/change_boot_anim/gif_to_raw.py
@@ -50,7 +50,7 @@ def extractGifFrames(inGif):
         while frame:
 #            newframe = frame.rotate(90).resize( SIZE, Image.ANTIALIAS).convert('RGBA')
             data = convert_frame_to_data(frame)
-            f.write(data.tostring())
+            f.write(data.tobytes())
             nframes += 1
             try:
                 frame.seek( nframes )
@@ -65,7 +65,7 @@ def convertImages(dirname, images):
         for filename in images:
             frame = Image.open(filename)
             data = convert_frame_to_data(frame)
-            f.write(data.tostring())
+            f.write(data.tobytes())
             nframes += 1
 
         print('wrote {} frames to {}'.format(nframes, outfilename))

--- a/examples/change_boot_anim/gif_to_raw.py
+++ b/examples/change_boot_anim/gif_to_raw.py
@@ -1,3 +1,5 @@
+# A brief script to convert GIF files to RAW with Vector's screen dimensions. Use GIF files that are 184x96 for best results.
+# Expected Python Version is 3.9.
 
 import os,sys
 #import struct


### PR DESCRIPTION
array.array doesn't have "tostring" in Python 3.9, so changing "tostring" to "tobytes".

This is confirmed to work clean on new images and I have made new boot images using the script- they work well.